### PR TITLE
Prevent emitting two successive errors when outputting to a zip file

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,7 +184,10 @@ Ogr2ogr.prototype._run = function () {
   })
 
   function wrapUp (er) {
-    if (er) ostream.emit('error', er)
+    if (er) {
+        ostream.emit('error', er);
+        return ogr2ogr._clean();
+    }
     if (!ogr2ogr._isZipOut) return ogr2ogr._clean()
 
     var zs = zip.createZipStream(ogr2ogr._ogrOutPath)


### PR DESCRIPTION
When creating a Shapefile (which outputs to a zip file), two errors are emitted. For example, if there is something wrong with the environment variables (gdal_data), I will get the first error (err.code = "ENOENT" and err.syscall = spawn) and then "File does not exist." because it is still trying to create the zip file even though the program failed to start. Not sure if it's the best way to handle it but it seems to me that the on error event shouldn't be sent twice.
