### PR TITLE
Ensure extractHead always call us back

### DIFF
--- a/lib/csv.js
+++ b/lib/csv.js
@@ -17,14 +17,17 @@ var extractHead = function (fpath, cb) {
   var data = ''
   sf.on('data', function (chunk) {
     data += chunk
-    if (data) sf.destroy()
+    if (data) {
+      sf.destroy()
+      sf.emit('end')
+    }
   })
   sf.on('error', one)
-  sf.on('end', function () {
+  sf.on('end', util.oneCallback(function () {
     csv().from.string(data).to.array(function (recs) {
       one(null, recs[0])
     })
-  })
+  }))
 }
 
 exports.makeVrt = function (fpath, cb) {


### PR DESCRIPTION
This is a very similar problem to the one that was fixed before.
In some cases, sf.destroy() just does not emit 'end' event.

Reading the nodejs docs, i realize `destroy` is not documented so its behavior is unpredictable.
