### PR TITLE
feat: add support for setting command env

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ Ogr2ogr.prototype.options = function(arr) {
   return this
 }
 
-Ogr2ogr.prototype.options = function(obj) {
+Ogr2ogr.prototype.env = function(obj) {
   this._env = obj
   return this
 }

--- a/index.js
+++ b/index.js
@@ -57,6 +57,11 @@ Ogr2ogr.prototype.options = function(arr) {
   return this
 }
 
+Ogr2ogr.prototype.options = function(obj) {
+  this._env = obj
+  return this
+}
+
 Ogr2ogr.prototype.destination = function(str) {
   this._destination = str
   return this
@@ -197,8 +202,9 @@ Ogr2ogr.prototype._run = function() {
     if (ogr2ogr._options) args = args.concat(ogr2ogr._options)
 
     var errbuf = ''
-
-    var s = cp.spawn('ogr2ogr', logCommand(args))
+    
+    var commandOptions = this._env ? { env: this._env } : undefined
+    var s = cp.spawn('ogr2ogr', logCommand(args), commandOptions)
 
     if (!ogr2ogr._isZipOut) s.stdout.pipe(ostream, {end: false})
 

--- a/readme.md
+++ b/readme.md
@@ -70,7 +70,8 @@ Available options include:
 - `.format(fmt)` - set output format (defaults to: "GeoJSON")
 - `.timeout(ms)` - milliseconds before ogr2ogr is killed (defaults to: 15000)
 - `.skipfailures()` - skip failures (continue after failure, skipping failed feature -- by default failures are not skipped)
-- `.options(arr)` - array of custom org2ogr arguments (e.g. `['-fieldmap', '2,-1,4']`)
+- `.env(obj)` - object of custom ogr2ogr ENV configuration parameters (e.g. `{ RFC7946: 'YES' }`)
+- `.options(arr)` - array of custom ogr2ogr arguments (e.g. `['-fieldmap', '2,-1,4']`)
 - `.destination(str)` - ogr2ogr destination (directly tell ogr2ogr where the output should go, useful for writing to databases)
 - `.onStderr(callback)` - execute a callback function whose parameter is the debug output of ogr2ogr to stderr
 


### PR DESCRIPTION
There are a lot of driver flags that have to be set via ENV vars (for example - changing the GeoJSON spec has to be done via a RFC7946=YES env var), so this adds a new `.env` function to set the flags for a command.