### PR TITLE
Fix crash on error when using stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -253,6 +253,7 @@ Ogr2ogr.prototype._run = function() {
   function wrapUp(er) {
     if (er) {
       ostream.emit('error', er)
+      ostream.emit('close')
       return ogr2ogr._clean()
     }
     if (!ogr2ogr._isZipOut) {
@@ -264,6 +265,7 @@ Ogr2ogr.prototype._run = function() {
     let zs = zip.createZipStream(ogr2ogr._ogrOutPath)
     zs.on('error', function(er2) {
       ostream.emit('error', er2)
+      ostream.emit('close')
     })
     zs.on('end', function() {
       ostream.emit('close')


### PR DESCRIPTION
The output stream was not closed after emitting the error. This was causing the main Node thread to crash with a segmentation fault, maybe when then spawn is cleaned up while still being attached to the open stream. This should fix https://github.com/wavded/ogr2ogr/issues/46 too

Happening for me on Node v10 and v12, possibly older versions are okay?

From the docs
>The stream is not closed when the 'error' event is emitted unless the autoDestroy option was set to true when creating the stream.

>After 'error', no further events other than 'close' should be emitted (including 'error' events).

https://nodejs.org/api/stream.html#stream_event_error