### PR TITLE
Updated Ogr2ogr constructor to allow for switching base command (#58)

### DIFF
--- a/examples/docker.js
+++ b/examples/docker.js
@@ -1,0 +1,12 @@
+const path = require('path')
+const ogr2ogr = require(path.join(__dirname, '../'))
+
+ogr2ogr(path.join(__dirname, '../test/samples/sample.shp.zip'))
+  .command('docker run --rm osgeo/gdal:alpine-small-latest ogr2ogr')
+  .exec(function (er, data) {
+    if (er) {
+      console.log('er', er)
+    } else {
+      console.log('data', data)
+    }
+  })

--- a/index.js
+++ b/index.js
@@ -88,6 +88,11 @@ Ogr2ogr.prototype.onStderr = function (fn) {
   return this
 }
 
+Ogr2ogr.prototype.command = function (str) {
+  this._command = str
+  return this
+}
+
 Ogr2ogr.prototype.exec = function (cb) {
   let ogr2ogr = this
   let buf = []
@@ -207,8 +212,9 @@ Ogr2ogr.prototype._run = function () {
 
     let errbuf = ''
 
+    let command = ogr2ogr._command || 'ogr2ogr'
     let commandOptions = this._env ? {env: this._env} : undefined
-    let s = cp.spawn('ogr2ogr', logCommand(args), commandOptions)
+    let s = cp.spawn(command, logCommand(args), commandOptions)
 
     if (!ogr2ogr._isZipOut) s.stdout.pipe(ostream, {end: false})
 


### PR DESCRIPTION
- Provided an additional function on the constructor for configuring the base command
- Updated the _run function to use the set base command when applicable
- Added an example that uses Docker instead of the ogr2ogr command 