### PR TITLE
Fix custom environment variables logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -213,9 +213,8 @@ Ogr2ogr.prototype._run = function () {
     let errbuf = ''
 
     let command = ogr2ogr._command || 'ogr2ogr'
-    let commandOptions = this._env ? {env: this._env} : undefined
+    let commandOptions = ogr2ogr._env ? {env: ogr2ogr._env} : undefined
     let s = cp.spawn(command, logCommand(args), commandOptions)
-
     if (!ogr2ogr._isZipOut) s.stdout.pipe(ostream, {end: false})
 
     let one = util.oneCallback(wrapUp)

--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,7 @@ Available options include:
 - `.format(fmt)` - set output format (defaults to: "GeoJSON")
 - `.timeout(ms)` - milliseconds before ogr2ogr is killed (defaults to: 15000)
 - `.skipfailures()` - skip failures (continue after failure, skipping failed feature -- by default failures are not skipped)
-- `.env(obj)` - object of custom ogr2ogr ENV configuration parameters (e.g. `{ RFC7946: 'YES' }`)
+- `.env(obj)` - object of custom ogr2ogr ENV configuration parameters (e.g. `{ ATTRIBUTES_SKIP: 'YES' }`)
 - `.options(arr)` - array of custom ogr2ogr arguments (e.g. `['-fieldmap', '2,-1,4']`)
 - `.destination(str)` - ogr2ogr destination (directly tell ogr2ogr where the output should go, useful for writing to databases)
 - `.onStderr(callback)` - execute a callback function whose parameter is the debug output of ogr2ogr to stderr

--- a/test/env-vars-test.js
+++ b/test/env-vars-test.js
@@ -15,18 +15,22 @@ test('env vars can be used', function (t) {
   t.plan(2)
 
   ogr2ogr(sampleGeojson)
-  .env({
-    ATTRIBUTES_SKIP: 'NO'
-  })
-  .exec(function (er, data) {
-    t.isEquivalent(data.features[0].properties, sampleGeojson.features[0].properties, 'has atrributes')
-  })
+    .env({
+      ATTRIBUTES_SKIP: 'NO',
+    })
+    .exec(function (er, data) {
+      t.isEquivalent(
+        data.features[0].properties,
+        sampleGeojson.features[0].properties,
+        'has atrributes'
+      )
+    })
 
   ogr2ogr(sampleGeojson)
-  .env({
-    ATTRIBUTES_SKIP: 'YES'
-  })
-  .exec(function (er, data) {
-    t.isEquivalent(data.features[0].properties, {}, 'has no atrributes')
-  })  
+    .env({
+      ATTRIBUTES_SKIP: 'YES',
+    })
+    .exec(function (er, data) {
+      t.isEquivalent(data.features[0].properties, {}, 'has no atrributes')
+    })
 })

--- a/test/env-vars-test.js
+++ b/test/env-vars-test.js
@@ -1,0 +1,32 @@
+const test = require('tape')
+const ogr2ogr = require('../')
+
+const sampleGeojson = {
+  type: 'FeatureCollection',
+  features: [
+    {
+      type: 'Feature',
+      properties: {area: '51'},
+    },
+  ],
+}
+
+test('env vars can be used', function (t) {
+  t.plan(2)
+
+  ogr2ogr(sampleGeojson)
+  .env({
+    ATTRIBUTES_SKIP: 'NO'
+  })
+  .exec(function (er, data) {
+    t.isEquivalent(data.features[0].properties, sampleGeojson.features[0].properties, 'has atrributes')
+  })
+
+  ogr2ogr(sampleGeojson)
+  .env({
+    ATTRIBUTES_SKIP: 'YES'
+  })
+  .exec(function (er, data) {
+    t.isEquivalent(data.features[0].properties, {}, 'has no atrributes')
+  })  
+})


### PR DESCRIPTION
In the current version ogr2ogr,  custom environment variables get ignored due to a bug in the code.

This PR aims to fix this and adds relevant tests as well as updated documentation.