### PR TITLE
Adds version() function

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -196,6 +196,18 @@ class Ogr2ogr implements PromiseLike<Result> {
   }
 }
 
-export default function ogr2ogr(input: Input, opts?: Options): Ogr2ogr {
+function ogr2ogr(input: Input, opts?: Options): Ogr2ogr {
   return new Ogr2ogr(input, opts)
 }
+
+ogr2ogr.version = async () => {
+  let vers = await new Promise<string>((res, rej) => {
+    execFile("ogr2ogr", ["--version"], {}, (err, stdout) => {
+      if (err) rej(err)
+      res(stdout)
+    })
+  })
+  return vers.trim()
+}
+
+export default ogr2ogr

--- a/index_test.ts
+++ b/index_test.ts
@@ -11,6 +11,9 @@ import ogr2ogr from "./"
 let dir = __dirname + "/testdata/"
 
 test(async (t) => {
+  const vers = await ogr2ogr.version()
+  t.match(vers, /^GDAL /)
+
   interface TT {
     file?: string
     url?: string

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ogr2ogr",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "ogr2ogr wrapper w/ multiple format support",
   "keywords": [
     "ogr2ogr",

--- a/readme.md
+++ b/readme.md
@@ -88,6 +88,17 @@ The **`output`** object has the following properties:
 
 The callback API supports the same options as above but in a NodeJS style callback format.
 
+### ogr2ogr.version() -> Promise\<string\>
+
+Retrieve the version of `ogr2ogr` that will be called by default by this library (same as calling `ogr2ogr --version` from command line).
+
+```javascript
+const version = await ogr2ogr.version()
+console.log(version)
+
+// GDAL X.X.X, released XXXX/XX/XX
+```
+
 ## Tips and tricks
 
 Running `ogr2ogr` in a [Docker container][6]:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "declaration": true,
     "outDir": "./dist/cjs",
     "esModuleInterop": true,
-    "resolveJsonModule": true,
+    "resolveJsonModule": true
   },
-  "exclude": ["node_modules", "dist"],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
resolves #107 

## what I like

It's fairly concise and easy to use.

## what I don't like

It doesn't honor the `command` arg on the default function and I don't think it should either. The point of `version()` is to understand what the lib is going to do by default. Ideally, it's something that you log or store for triage purposes. If an implementer is calling `ogr2ogr` from a novel location, I suspect that knowing the version number isn't something they're interested in. Additionally, honoring the `command` arg would require significant rework of the default function, as the `input` arg would not make sense in the context of getting the version of the command line utility. Alternatively, one could argue that the `version` function could simply take in a `command` arg and solve this problem, but I'm not sure if that's desired. Happy to take feedback here.